### PR TITLE
Logs: improve logs styling

### DIFF
--- a/src/templates/css.ts
+++ b/src/templates/css.ts
@@ -156,10 +156,20 @@ button {
 
 .text-extra {
   color: var(--extra-color);
+  margin: 0;
 }
 
 .log-text {
   color: var(--font-color);
+}
+
+.log-func {
+  color: var(--extra-color);
+  margin: 0;
+}
+
+.log-func:hover {
+  background-color: var(--secondary-color);
 }
 
 .function-box {

--- a/src/templates/pageTemplates.ts
+++ b/src/templates/pageTemplates.ts
@@ -123,7 +123,7 @@ export default function Details(props${useTs ? ": Props" : ""}) {
   const logs = (key${ useTs ? ": string" : ""}, value${ useTs ? ": string" : ""}, index${ useTs ? ": number" : ""}) => {
     return (
       <div key={index} className="log-box">
-        <p className="text-extra">{key}: <span className="log-text">{value}</span></p>
+        <p className="log-func">{key}: <span className="log-text">{value}</span></p>
       </div>
     )
   }

--- a/src/templates/theme.ts
+++ b/src/templates/theme.ts
@@ -15,7 +15,7 @@ export default function theme(useTs: boolean) {
       light: {
         main: '#FDFDFC',
         heading: '#4B4367',
-        secondary: '#8781AA',
+        secondary: '#B0BFD4',
         font: '#0A0613',
         extra: '#4252BB',
       }


### PR DESCRIPTION
Fixes #19
Dark theme:
<img width="784" alt="Screenshot 2022-07-18 at 11 37 47" src="https://user-images.githubusercontent.com/67058118/179494683-816f1dd7-d200-4349-8795-867be76db975.png">
Light theme:
<img width="783" alt="Screenshot 2022-07-18 at 11 37 36" src="https://user-images.githubusercontent.com/67058118/179494691-14d500eb-b621-462b-994d-2d9f66520c23.png">
 